### PR TITLE
Fix loading config.js file

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,18 +6,14 @@
 
 const { name: appName, version, description } = require('./package')
 const {
-  getFilePathOrFallback,
+  getConfigFile,
   listFunctionsAndAliases,
   setClipboard,
   setUserConfig,
 } = require('./utils')
 
 const configFile = './config.js'
-const userConfigFile = `${process.env.XDG_CONFIG_DIR}/${appName}/${configFile}`
-
-const { aliases, functions } = require(
-  getFilePathOrFallback(userConfigFile, configFile)
-)
+const { aliases, functions } = require(getConfigFile(configFile))
 
 const { log } = console
 const { argv, exit } = process

--- a/utils.js
+++ b/utils.js
@@ -5,13 +5,19 @@ const path = require('path')
 const { name: appName } = require('./package')
 
 const { log } = console
+const { env } = process
 
 const fileExists = (filePath) => fs.existsSync(filePath)
 
 const getClipboard = () => clipboardy.readSync()
 
-const getFilePathOrFallback = (file, fallback) =>
-  fileExists(file) ? file : fallback
+const getConfigFile = (fileName) => {
+  const appConfigPath = `${getOsConfigDir()}/${appName}/${fileName}`
+  return fileExists(appConfigPath) ? appConfigPath : fileName
+}
+
+const getOsConfigDir = () =>
+  env.XDG_CONFIG_DIR ?? path.join(os.homedir(), '.config')
 
 const listFunctionsAndAliases = (functions, aliases) =>
   Object.keys(functions)
@@ -22,9 +28,7 @@ const setClipboard = (value) => clipboardy.writeSync(value)
 
 const setUserConfig = (configFile) => {
   // TODO: does this work on Windows?
-  const configDir =
-    process.env.XDG_CONFIG_DIR || path.join(os.homedir(), '.config')
-  const targetDir = path.join(configDir, appName)
+  const targetDir = path.join(getOsConfigDir(), appName)
 
   !fileExists(targetDir) && fs.mkdirSync(targetDir, { recursive: true })
 
@@ -44,7 +48,7 @@ const setUserConfig = (configFile) => {
 module.exports = {
   fileExists,
   getClipboard,
-  getFilePathOrFallback,
+  getConfigFile,
   listFunctionsAndAliases,
   setClipboard,
   setUserConfig,


### PR DESCRIPTION
The envvar `XDG_CONFIG_DIR` might be missing, making it impossible to find the OS config directory. If this occurs, the path is now manually set.