### PR TITLE
Add `findFunctionByNameOrAlias` tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,12 +92,16 @@ const applyTransform = (arg) => {
   }
 }
 
-hasArg('-l') && logAndExit(listFunctionsAndAliases(functions, aliases))
+if (require.main === module) {
+  hasArg('-l') && logAndExit(listFunctionsAndAliases(functions, aliases))
 
-hasArg('-i') && logAndExit(setUserConfig(configFileName))
+  hasArg('-i') && logAndExit(setUserConfig(configFileName))
 
-hasArg('-h') && showHelp(0)
+  hasArg('-h') && showHelp(0)
 
-!args.length && showHelp(1)
+  !args.length && showHelp(1)
 
-args.forEach((arg) => !['-L', '-q'].includes(arg) && applyTransform(arg))
+  args.forEach((arg) => !['-L', '-q'].includes(arg) && applyTransform(arg))
+}
+
+module.exports = { findFunctionByNameOrAlias }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test"
   },
   "repository": {
     "type": "git",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,25 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const path = require('node:path')
+
+const originalMainModule = process.mainModule
+process.mainModule = { path: path.join(__dirname, '..') }
+
+const { findFunctionByNameOrAlias } = require('../index.js')
+const { functions } = require('../config.js')
+
+process.mainModule = originalMainModule
+
+test('Function name matching with different cases', () => {
+  assert.strictEqual(findFunctionByNameOrAlias('trim'), functions.trim)
+  assert.strictEqual(findFunctionByNameOrAlias('TRIM'), functions.trim)
+})
+
+test('Alias matching with different cases', () => {
+  assert.strictEqual(findFunctionByNameOrAlias('dq'), functions.doubleQuote)
+  assert.strictEqual(findFunctionByNameOrAlias('DQ'), functions.doubleQuote)
+})
+
+test('Returns undefined when no match is found', () => {
+  assert.strictEqual(findFunctionByNameOrAlias('nonexistent'), undefined)
+})


### PR DESCRIPTION
## Summary
- export `findFunctionByNameOrAlias` and only run CLI logic when executed directly
- add node:test suite for case-insensitive name/alias matching and missing functions
- use Node's built-in test runner
- move module.exports to end of `index.js`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895d2aedbc48325a1c9ed5536517555